### PR TITLE
Upgrade checkstyle library to 6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project provides an SBT 0.13+ plugin for running Checkstyle over
 Java source files.  For more information about Checkstyle, see
 [http://checkstyle.sourceforge.net/](http://checkstyle.sourceforge.net/)
 
-This plugin uses version 5.5 of Checkstyle.
+This plugin uses version 6.1 of Checkstyle.
 
 This is a fork of the sbt-code-quality project found
 [here](https://github.com/corux/sbt-code-quality).
@@ -14,7 +14,7 @@ This is a fork of the sbt-code-quality project found
 Add the following lines to `project/plugins.sbt`
 
 ```scala
-addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "0.4.0")
+addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "0.4.1-SNAPSHOT")
 ```
 
 Then add the following line to `build.sbt`:

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ organization := "com.etsy"
 version := "0.4.0-SNAPSHOT"
 
 libraryDependencies ++= Seq(
-  "com.puppycrawl.tools" % "checkstyle" % "5.5",
+  "com.puppycrawl.tools" % "checkstyle" % "6.1",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "junit" % "junit" % "4.11" % "test",
   "com.github.stefanbirkner" % "system-rules" % "1.6.0" % "test"


### PR DESCRIPTION
Hello,

This request upgrades the checkstyle version for 5.5 to 6.1.

We are using the Google Java Style checkstyle rules and using version 5.5 we need to remove quite a few rules from the checkstyle config file.

I did a local publish of with these changes and used in in our main project with success.

Kind regards,

Hans
