### PR TITLE
Upgrade checkstyle library to 6.5, remove deprecated -r arg and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project provides an SBT 0.13+ plugin for running Checkstyle over
 Java source files.  For more information about Checkstyle, see
 [http://checkstyle.sourceforge.net/](http://checkstyle.sourceforge.net/)
 
-This plugin uses version 6.1 of Checkstyle.
+This plugin uses version 6.5 of Checkstyle.
 
 This is a fork of the sbt-code-quality project found
 [here](https://github.com/corux/sbt-code-quality).

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ organization := "com.etsy"
 version := "0.4.2-SNAPSHOT"
 
 libraryDependencies ++= Seq(
-  "com.puppycrawl.tools" % "checkstyle" % "6.1",
+  "com.puppycrawl.tools" % "checkstyle" % "6.5",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "junit" % "junit" % "4.11" % "test",
   "com.github.stefanbirkner" % "system-rules" % "1.6.0" % "test"

--- a/src/main/scala/com/etsy/sbt/Checkstyle.scala
+++ b/src/main/scala/com/etsy/sbt/Checkstyle.scala
@@ -26,8 +26,8 @@ object Checkstyle extends Plugin {
     */
   def checkstyleTask(conf: Configuration): Initialize[Task[Unit]] = Def.task {
     val checkstyleArgs = Array(
-      "-c", (checkstyleConfig in conf).value.getAbsolutePath, // checkstyle configuration fle
-      "-r", (javaSource in conf).value.getAbsolutePath, // location of Java source files
+      "-c", (checkstyleConfig in conf).value.getAbsolutePath, // checkstyle configuration file
+      (javaSource in conf).value.getAbsolutePath, // location of Java source file
       "-f", "xml", // output format
       "-o", (checkstyleTarget in conf).value.getAbsolutePath // output file
     )


### PR DESCRIPTION
Hi,

this commits upgrades checkstyle to version 6.5.

As the -r command line argument was removed, the arg passing had to be rearanged.

The commit has been tested with my project using the configuration file for Google Java Style ( http://checkstyle.sourceforge.net/google_style.html ).

It would be nice, to see this merged back.

Thanks for your work!