### PR TITLE
Cross build plugin for SBT 0.13.x & 1.0.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ checkstyleConfigLocation := CheckstyleConfigLocation.Classpath("com/etsy/checkst
 
 To run Checkstyle automatically after compilation:
 ```scala
-(checkstyle in Compile) <<= (checkstyle in Compile) triggeredBy (compile in Compile)
+(checkstyle in Compile) := (checkstyle in Compile).triggeredBy(compile in Compile).value
 ```
 
 To run Checkstyle automatically after test compilation:
 ```scala
-(checkstyle in Test) <<= (checkstyle in Test) triggeredBy (compile in Test)
+(checkstyle in Test) := (checkstyle in Test).triggeredBy(compile in Test).value
 ```
 
 ### XSLT transformations
@@ -92,8 +92,8 @@ lazy val root = (project in file(".")).configs(IntegrationTest)
 Defaults.itSettings
 
 checkstyleConfigLocation := CheckstyleConfigLocation.File("my-checkstyle-config.xml"),
-checkstyle in IntegrationTest <<= checkstyleTask(IntegrationTest),
-checkstyleOutputFile in IntegrationTest <<= target(_ / "checkstyle-integration-test-report.xml")
+checkstyle in IntegrationTest := checkstyleTask(IntegrationTest).value,
+checkstyleOutputFile in IntegrationTest := target.value / "checkstyle-integration-test-report.xml"
 ```
 
 You can then run the tasks `it:checkstyle` and `it:checkstyle-check`.

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.etsy"
 version := "3.0.1-SNAPSHOT"
 
 sbtPlugin := true
-crossSbtVersions := Seq("0.13.16", "1.0.1")
+crossSbtVersions := Seq("0.13.16", "1.1.0")
 
 libraryDependencies ++= Seq(
   "com.puppycrawl.tools"      %  "checkstyle"   % "6.15",

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,10 @@
-sbtPlugin := true
-
 name := "sbt-checkstyle-plugin"
-
 organization := "com.etsy"
 
 version := "3.0.1-SNAPSHOT"
 
-scalaVersion := "2.10.4"
+sbtPlugin := true
+crossSbtVersions := Seq("0.13.16", "1.0.1")
 
 libraryDependencies ++= Seq(
   "com.puppycrawl.tools" % "checkstyle" % "6.15",

--- a/build.sbt
+++ b/build.sbt
@@ -7,11 +7,11 @@ sbtPlugin := true
 crossSbtVersions := Seq("0.13.16", "1.0.1")
 
 libraryDependencies ++= Seq(
-  "com.puppycrawl.tools" % "checkstyle" % "6.15",
-  "net.sf.saxon" % "Saxon-HE" % "9.6.0-5",
-  "org.scalatest" % "scalatest_2.10" % "2.2.1" % "test",
-  "junit" % "junit" % "4.11" % "test",
-  "com.github.stefanbirkner" % "system-rules" % "1.6.0" % "test"
+  "com.puppycrawl.tools"      %  "checkstyle"   % "6.15",
+  "net.sf.saxon"              %  "Saxon-HE"     % "9.6.0-5",
+  "org.scalatest"             %% "scalatest"    % "3.0.4"   % "test",
+  "junit"                     %  "junit"        % "4.11"    % "test",
+  "com.github.stefanbirkner"  %  "system-rules" % "1.6.0"   % "test"
 )
 
 xerial.sbt.Sonatype.sonatypeSettings

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.16

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
-
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/project/scripted.sbt
+++ b/project/scripted.sbt
@@ -1,1 +1,1 @@
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/project/scripted.sbt
+++ b/project/scripted.sbt
@@ -1,3 +1,1 @@
-libraryDependencies <+= (sbtVersion) { sv =>
-  "org.scala-sbt" % "scripted-plugin" % sv
-}
+libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/scripted.sbt
+++ b/scripted.sbt
@@ -1,5 +1,3 @@
-ScriptedPlugin.scriptedSettings
-
 scriptedLaunchOpts := { scriptedLaunchOpts.value ++
   Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value)
 }

--- a/src/main/scala/com/etsy/sbt/checkstyle/CheckstylePlugin.scala
+++ b/src/main/scala/com/etsy/sbt/checkstyle/CheckstylePlugin.scala
@@ -47,11 +47,11 @@ object CheckstylePlugin extends AutoPlugin {
   )
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = Seq(
-    checkstyleOutputFile <<= target(_ / "checkstyle-report.xml"),
-    checkstyleOutputFile in Test <<= target(_ / "checkstyle-test-report.xml"),
+    checkstyleOutputFile := target.value / "checkstyle-report.xml",
+    checkstyleOutputFile in Test := target.value / "checkstyle-test-report.xml",
     checkstyleConfigLocation := com.etsy.sbt.checkstyle.CheckstyleConfigLocation.File("checkstyle-config.xml"),
-    checkstyleConfigLocation in Test <<= checkstyleConfigLocation,
-    checkstyle <<= checkstyleTask(Compile),
-    checkstyle in Test <<= checkstyleTask(Test)
+    checkstyleConfigLocation in Test := checkstyleConfigLocation.value,
+    checkstyle := checkstyleTask(Compile).value,
+    checkstyle in Test := checkstyleTask(Test).value
   ) ++ commonSettings
 }

--- a/src/sbt-test/checkstyle/checkstyle-auto/build.sbt
+++ b/src/sbt-test/checkstyle/checkstyle-auto/build.sbt
@@ -6,4 +6,4 @@ organization := "com.etsy"
 
 checkstyleConfigLocation := CheckstyleConfigLocation.File("checkstyle-config.xml")
 
-(checkstyle in Compile) <<= (checkstyle in Compile) triggeredBy (compile in Compile)
+(checkstyle in Compile) := (checkstyle in Compile).triggeredBy(compile in Compile).value

--- a/src/sbt-test/checkstyle/checkstyle-integration-test/build.sbt
+++ b/src/sbt-test/checkstyle/checkstyle-integration-test/build.sbt
@@ -9,5 +9,5 @@ lazy val root = (project in file(".")).configs(IntegrationTest)
 Defaults.itSettings
 
 checkstyleConfigLocation := CheckstyleConfigLocation.File("my-checkstyle-config.xml")
-checkstyle in IntegrationTest <<= checkstyleTask(IntegrationTest)
-checkstyleOutputFile in IntegrationTest <<= target(_ / "checkstyle-integration-test-report.xml")
+checkstyle in IntegrationTest := checkstyleTask(IntegrationTest).value
+checkstyleOutputFile in IntegrationTest := target.value / "checkstyle-integration-test-report.xml"

--- a/src/sbt-test/checkstyle/checkstyle-test-auto/build.sbt
+++ b/src/sbt-test/checkstyle/checkstyle-test-auto/build.sbt
@@ -4,4 +4,4 @@ name := "checkstyle-test-auto"
 
 organization := "com.etsy"
 
-(checkstyle in Test) <<= (checkstyle in Test) triggeredBy (compile in Test)
+(checkstyle in Test) := (checkstyle in Test).triggeredBy(compile in Test).value


### PR DESCRIPTION
Includes:

* Update project SBT to 0.13.16.
* Fix deprecated syntax in project & scripted tests.
* Add cross build settings for 0.13.16 & 1.0.1